### PR TITLE
Mention Azurite in-memory persistence option

### DIFF
--- a/docs/automated-testing/tech-specific-samples/blobstorage-unit-tests/README.md
+++ b/docs/automated-testing/tech-specific-samples/blobstorage-unit-tests/README.md
@@ -33,6 +33,8 @@ mkdir c:/azurite
 azurite --silent --location c:\azurite --debug c:\azurite\debug.log
 ```
 
+If you want to avoid any disk persistence and destroy the test data when the Azurite process terminates, you can pass the `--inMemoryPersistence` option, as of Azurite 3.28.0.
+
 The output will be:
 
 ```shell


### PR DESCRIPTION
# Pull Request Template

## What are you trying to address

I made an OSS contribution to Azurite to implement `--inMemoryPersistence`. This disables the disk storage which is ideal for test runs so there's no left over test data you need to clean up.

README on Azurite: https://github.com/Azure/azurite#use-in-memory-storage

A blog post I wrote about it: https://www.joelverhagen.com/blog/2023/11/azurite-in-memory

